### PR TITLE
Fixed overwrite config parameter

### DIFF
--- a/src/groovy/CoreTemplateGenerator.groovy
+++ b/src/groovy/CoreTemplateGenerator.groovy
@@ -70,7 +70,7 @@ class CoreTemplateGenerator {
 
 		pluginConfig = grailsApplication.config.grails.plugin.scaffold.core
 		APP_URL = pluginConfig.appUrl ?: ''
-		overwrite = pluginConfig.overwrite ?: true
+		overwrite = pluginConfig.overwrite != null ? pluginConfig.overwrite : true
 		ignoreFileNames = pluginConfig.ignoreFileNames ?: []
 		ignoreDomainNames = pluginConfig.ignoreDomainNames ?: []
 		ignoreStatic = pluginConfig.ignoreStatic ?: false


### PR DESCRIPTION
Although the value of overwrite config parameter was set to false, its value would be always true:

```
grails.plugin.scaffold.core.overwrite = false
```

The problem was line 73 of CoreTemplateGenerator:

```
overwrite = pluginConfig.overwrite ?: true
```
